### PR TITLE
Fix latin-1 encoding error when saving LLM-enhanced notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to GPGNotes will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.7] - 2025-12-16
+
+### Fixed
+
+- **LLM Encoding Error**: Fixed `latin-1` codec error when saving LLM-enhanced notes. Added `sanitize_llm_output()` function to convert Unicode characters (smart quotes, em dashes, ellipsis, etc.) to ASCII equivalents before GPG encryption. Fixes #1.
+
 ## [0.1.6] - 2025-12-16
 
 ### Fixed
@@ -168,6 +174,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sync requires Git remote to be configured manually
 - Initial sync from existing remote requires `--allow-unrelated-histories` (handled automatically)
 
+[0.1.7]: https://github.com/oscarvalenzuelab/GPGNotes/releases/tag/v0.1.7
 [0.1.6]: https://github.com/oscarvalenzuelab/GPGNotes/releases/tag/v0.1.6
 [0.1.5]: https://github.com/oscarvalenzuelab/GPGNotes/releases/tag/v0.1.5
 [0.1.4]: https://github.com/oscarvalenzuelab/GPGNotes/releases/tag/v0.1.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpgnotes"
-version = "0.1.6"
+version = "0.1.7"
 description = "GPGNotes - A CLI note-taking tool with GPG encryption, tagging, and Git sync"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/gpgnotes/llm.py
+++ b/src/gpgnotes/llm.py
@@ -20,24 +20,24 @@ def sanitize_llm_output(text: str) -> str:
     """
     # Common Unicode replacements (smart quotes, dashes, etc.)
     replacements = {
-        '\u2018': "'",   # Left single quotation mark
-        '\u2019': "'",   # Right single quotation mark
-        '\u201c': '"',   # Left double quotation mark
-        '\u201d': '"',   # Right double quotation mark
-        '\u2013': '-',   # En dash
-        '\u2014': '--',  # Em dash
-        '\u2026': '...', # Horizontal ellipsis
-        '\u00a0': ' ',   # Non-breaking space
-        '\u2022': '*',   # Bullet
-        '\u2023': '>',   # Triangular bullet
-        '\u2043': '-',   # Hyphen bullet
-        '\u00b7': '*',   # Middle dot
-        '\u2212': '-',   # Minus sign
-        '\u00ad': '',    # Soft hyphen (invisible)
-        '\ufeff': '',    # BOM / zero-width no-break space
-        '\u200b': '',    # Zero-width space
-        '\u200c': '',    # Zero-width non-joiner
-        '\u200d': '',    # Zero-width joiner
+        "\u2018": "'",  # Left single quotation mark
+        "\u2019": "'",  # Right single quotation mark
+        "\u201c": '"',  # Left double quotation mark
+        "\u201d": '"',  # Right double quotation mark
+        "\u2013": "-",  # En dash
+        "\u2014": "--",  # Em dash
+        "\u2026": "...",  # Horizontal ellipsis
+        "\u00a0": " ",  # Non-breaking space
+        "\u2022": "*",  # Bullet
+        "\u2023": ">",  # Triangular bullet
+        "\u2043": "-",  # Hyphen bullet
+        "\u00b7": "*",  # Middle dot
+        "\u2212": "-",  # Minus sign
+        "\u00ad": "",  # Soft hyphen (invisible)
+        "\ufeff": "",  # BOM / zero-width no-break space
+        "\u200b": "",  # Zero-width space
+        "\u200c": "",  # Zero-width non-joiner
+        "\u200d": "",  # Zero-width joiner
     }
 
     for unicode_char, replacement in replacements.items():
@@ -45,10 +45,10 @@ def sanitize_llm_output(text: str) -> str:
 
     # Remove any remaining characters that can't be encoded in latin-1
     try:
-        text.encode('latin-1')
+        text.encode("latin-1")
     except UnicodeEncodeError:
         # Filter out non-encodable characters
-        text = ''.join(c if ord(c) < 256 else '?' for c in text)
+        text = "".join(c if ord(c) < 256 else "?" for c in text)
 
     return text
 


### PR DESCRIPTION
## Summary

- Add `sanitize_llm_output()` function to convert Unicode characters to ASCII equivalents
- Apply sanitization to all three LLM providers (OpenAI, Claude, Ollama)

## Problem

The `python-gnupg` library uses latin-1 encoding internally. LLMs frequently return "smart" Unicode characters like:
- `'` (U+2019) instead of `'`
- `"` `"` (U+201C/U+201D) instead of `"`
- `—` (U+2014) instead of `--`

These cannot be encoded in latin-1, causing encryption to fail with errors like:
```
Error: 'latin-1' codec can't encode character '\u2019' in position 1206
```

## Solution

The new `sanitize_llm_output()` function:
1. Replaces common Unicode characters with ASCII equivalents (smart quotes, dashes, ellipsis, bullets)
2. Removes invisible characters (zero-width spaces, BOM, soft hyphens)
3. Falls back to replacing any remaining non-latin-1 characters with `?`

The fix preserves markdown formatting while ensuring all output can be safely encrypted.

## Test plan

- [x] Verified sanitization converts smart quotes, dashes, ellipsis correctly
- [x] Verified markdown formatting is preserved after sanitization
- [x] Verified all sanitized output can be encoded in latin-1

Fixes #1