### PR TITLE
Bump version to 0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to GPGNotes will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.9] - 2025-12-16
+
+### Fixed
+
+- **PDF Export Dependency**: Added missing `reportlab` to `[import]` optional dependencies for PDF export.
+- **Documentation**: Clarified pipx installation instructions with both `pipx install gpgnotes[import]` and `pipx inject` options.
+
 ## [0.1.8] - 2025-12-16
 
 ### Added
@@ -210,6 +217,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sync requires Git remote to be configured manually
 - Initial sync from existing remote requires `--allow-unrelated-histories` (handled automatically)
 
+[0.1.9]: https://github.com/oscarvalenzuelab/GPGNotes/releases/tag/v0.1.9
 [0.1.8]: https://github.com/oscarvalenzuelab/GPGNotes/releases/tag/v0.1.8
 [0.1.7]: https://github.com/oscarvalenzuelab/GPGNotes/releases/tag/v0.1.7
 [0.1.6]: https://github.com/oscarvalenzuelab/GPGNotes/releases/tag/v0.1.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpgnotes"
-version = "0.1.8"
+version = "0.1.9"
 description = "GPGNotes - A CLI note-taking tool with GPG encryption, tagging, and Git sync"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Bump version to 0.1.10 with bug fix for plain export sync.

### v0.1.10 Fix
- **Plain Export Sync**: Fixed `--plain` export not syncing with Git
  - Plain files now export to `~/.gpgnotes/notes/plain/` (inside Git repo)
  - Previously exported to `~/.gpgnotes/plain/` (outside Git repo)

### Also includes v0.1.9 fixes
- Added missing `reportlab` to `[import]` dependencies for PDF export
- Clarified pipx installation instructions in README