### PR TITLE
Improve note access with flexible identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to GPGNotes will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.10] - 2025-12-16
+
+### Added
+
+- **Open Most Recent Note**: `notes open --last` opens the most recently modified note.
+- **Title-Based Fuzzy Matching**: Open notes by title with `notes open "meeting"` - shows matches for selection.
+- **Enhanced List Command**: New options for `notes list`:
+  - `--preview` / `-p`: Show first line of content
+  - `--sort` / `-s`: Sort by `modified`, `created`, or `title`
+  - `--limit` / `-n`: Set maximum notes to display
+  - `--tag` / `-t`: Filter notes by tag
+- **Recent Notes Command**: `notes recent` as shortcut for `notes list --sort modified -n 5`.
+- **Note Title Autocomplete**: Tab completion for note titles in interactive mode after `open`, `delete`, `export`, `enhance` commands.
+
+### Changed
+
+- **Interactive Mode**: Updated help text to reflect new features and autocomplete capability.
+
 ## [0.1.9] - 2025-12-16
 
 ### Fixed
@@ -217,6 +235,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sync requires Git remote to be configured manually
 - Initial sync from existing remote requires `--allow-unrelated-histories` (handled automatically)
 
+[0.1.10]: https://github.com/oscarvalenzuelab/GPGNotes/releases/tag/v0.1.10
 [0.1.9]: https://github.com/oscarvalenzuelab/GPGNotes/releases/tag/v0.1.9
 [0.1.8]: https://github.com/oscarvalenzuelab/GPGNotes/releases/tag/v0.1.8
 [0.1.7]: https://github.com/oscarvalenzuelab/GPGNotes/releases/tag/v0.1.7

--- a/README.md
+++ b/README.md
@@ -94,9 +94,18 @@ notes search --tag work
 
 # Open/edit a note
 notes open <note-id>
+notes open "meeting"    # Fuzzy match by title
+notes open --last       # Open most recent
 
 # List all notes
 notes list
+notes list --preview              # Show content preview
+notes list --sort title           # Sort by title
+notes list --tag work --limit 10  # Filter and limit
+
+# Recent notes (shortcut)
+notes recent         # Last 5 notes
+notes recent -n 10   # Last 10 notes
 
 # Show all tags
 notes tags
@@ -149,8 +158,9 @@ notes
 
 In interactive mode, you can:
 - Type any text to search
-- Use commands: `new`, `list`, `tags`, `sync`, `config`, `exit`
-- Navigate results with tab completion
+- Use commands: `new`, `list`, `recent`, `open`, `tags`, `sync`, `config`, `exit`
+- Tab-complete note titles after `open`, `delete`, `export`, `enhance`
+- Use Up/Down arrows to navigate command history
 
 ## Directory Structure
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpgnotes"
-version = "0.1.9"
+version = "0.1.10"
 description = "GPGNotes - A CLI note-taking tool with GPG encryption, tagging, and Git sync"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Closes #4

- **Open most recent note**: `notes open --last` opens the most recently modified note
- **Fuzzy title matching**: `notes open "meeting"` finds notes by title with interactive selection for multiple matches
- **Enhanced list command**: 
  - `--preview` / `-p`: Show first line of content
  - `--sort` / `-s`: Sort by `modified`, `created`, or `title`
  - `--limit` / `-n`: Set maximum notes to display
  - `--tag` / `-t`: Filter notes by tag
- **Recent command**: `notes recent` as shortcut for `notes list --sort modified -n 5`
- **Tab completion**: Note titles auto-complete in interactive mode after `open`, `delete`, `export`, `enhance` commands

## Test plan

- [x] Run `ruff check` - passes
- [x] Run `pytest` - 29 tests pass
- [ ] Test `notes open --last` opens most recent note
- [ ] Test `notes open "title"` fuzzy matching
- [ ] Test `notes list --preview --sort title --tag work`
- [ ] Test `notes recent` command
- [ ] Test tab completion in interactive mode