### PR TITLE
Fix plain export sync with git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to GPGNotes will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.11] - 2025-12-16
+
+### Fixed
+
+- **Plain Export Sync**: Fixed `--plain` export path to be inside the git repository (`notes/plain/`) so files sync correctly with `notes sync`.
+
 ## [0.1.10] - 2025-12-16
 
 ### Added
@@ -235,6 +241,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sync requires Git remote to be configured manually
 - Initial sync from existing remote requires `--allow-unrelated-histories` (handled automatically)
 
+[0.1.11]: https://github.com/oscarvalenzuelab/GPGNotes/releases/tag/v0.1.11
 [0.1.10]: https://github.com/oscarvalenzuelab/GPGNotes/releases/tag/v0.1.10
 [0.1.9]: https://github.com/oscarvalenzuelab/GPGNotes/releases/tag/v0.1.9
 [0.1.8]: https://github.com/oscarvalenzuelab/GPGNotes/releases/tag/v0.1.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpgnotes"
-version = "0.1.10"
+version = "0.1.11"
 description = "GPGNotes - A CLI note-taking tool with GPG encryption, tagging, and Git sync"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/gpgnotes/cli.py
+++ b/src/gpgnotes/cli.py
@@ -1123,7 +1123,8 @@ def export(note_id, format, output, plain):
             ext = extensions.get(format, ".md")
 
             # Create plain folder path mirroring the notes structure
-            plain_dir = config.config_dir / "plain"
+            # Must be inside notes_dir so it's included in git sync
+            plain_dir = config.notes_dir / "plain"
             # Use note's relative path (YYYY/MM/filename)
             rel_path = file_path.relative_to(config.notes_dir)
             # Change extension from .md.gpg to the export format


### PR DESCRIPTION
## Summary

Fixes plain text export not syncing with `notes sync`.

The `--plain` export was writing files to `~/.gpgnotes/plain/` (config_dir) but the git repository is at `~/.gpgnotes/notes/` (notes_dir). This meant plain exports were outside the git repo and never synced.

**Fix:** Changed `plain_dir` from `config.config_dir / "plain"` to `config.notes_dir / "plain"` so plain files are now at `~/.gpgnotes/notes/plain/` inside the git repository.

## Test plan

- [ ] Export a note with `notes export <id> --plain`
- [ ] Verify file is created at `~/.gpgnotes/notes/plain/YYYY/MM/filename.md`
- [ ] Run `notes sync`
- [ ] Verify plain files are committed and pushed