### PR TITLE
Fix pyproject.toml version to 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpgnotes"
-version = "0.1.13"
+version = "0.2.1"
 description = "GPGNotes - A CLI note-taking tool with GPG encryption, tagging, and Git sync"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Fixes missing version update in pyproject.toml that was causing PyPI upload to fail with old version 0.1.13.

This completes the version bump to 0.2.1.