### PR TITLE
Fix version to 0.2.1 and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ A CLI note-taking tool with GPG encryption, automatic tagging, full-text search,
 - **Full-Text Search** - Fast SQLite FTS5-powered search across all notes
 - **Auto-Tagging** - Intelligent tag generation using TF-IDF
 - **Git Sync** - Automatic synchronization with private GitHub repositories
+- **Note Templates** - Built-in templates (meeting, project, bug, journal, research) with custom template support
+- **Version History** - Git-based version tracking with history, diff, and restore commands
+- **Markdown Rendering** - Rich terminal preview with formatted display
+- **URL Import** - Web clipper to import content from URLs
+- **Pagination** - Interactive pagination for list and search results
 - **AI Enhancement** - Optional LLM-powered note refinement ([docs](docs/ai-enhancement.md))
 - **Import/Export** - Support for PDF, DOCX, RTF formats ([docs](docs/import-export.md))
 
@@ -84,20 +89,31 @@ notes sync
 | Command | Description |
 |---------|-------------|
 | `notes new "Title"` | Create a new note |
+| `notes new --template meeting` | Create note from template |
 | `notes list` | List all notes |
 | `notes list --preview` | List with content preview |
+| `notes list --page-size 10` | List with custom pagination |
 | `notes recent` | Show 5 most recent notes |
 | `notes search "query"` | Full-text search |
 | `notes search --tag work` | Search by tag |
 | `notes open <id>` | Open note by ID |
 | `notes open "title"` | Open by title (fuzzy match) |
 | `notes open --last` | Open most recent note |
+| `notes show <id> --render` | Display note with formatting |
+| `notes preview <id>` | Rich markdown preview |
+| `notes history <id>` | Show version history |
+| `notes diff <id> --from <commit>` | Compare versions |
+| `notes restore <id> --version <commit>` | Restore previous version |
+| `notes template list` | List all templates |
+| `notes template show <name>` | Preview a template |
 | `notes tags` | List all tags |
 | `notes delete <id>` | Delete a note |
 | `notes sync` | Sync with Git |
 | `notes config --show` | Show configuration |
 | `notes enhance <id>` | AI enhancement ([docs](docs/ai-enhancement.md)) |
 | `notes import file.pdf` | Import file ([docs](docs/import-export.md)) |
+| `notes import <url>` | Import from URL (web clipper) |
+| `notes clip <url>` | Web clipper shortcut |
 | `notes export <id>` | Export note ([docs](docs/import-export.md)) |
 
 ### Interactive Mode

--- a/docs/import-export.md
+++ b/docs/import-export.md
@@ -45,6 +45,43 @@ notes import *.md
 | PDF | `.pdf` | Requires pypdf |
 | Word Document | `.docx` | Requires python-docx |
 
+## URL Import (Web Clipper)
+
+Import content directly from web pages as encrypted notes:
+
+```bash
+# Import from URL
+notes import https://example.com/article
+
+# Use the clip shortcut
+notes clip https://blog.example.com/post
+
+# Import with custom title
+notes import https://example.com --title "My Custom Title"
+```
+
+### Features
+
+- **HTML to Markdown conversion** - Automatically converts web content to markdown format
+- **Automatic title extraction** - Extracts title from the page's first heading
+- **Metadata preservation** - Adds source URL and clipped timestamp to note frontmatter
+- **No dependencies** - Uses built-in Python libraries (urllib, HTMLParser)
+
+### Example Output
+
+```markdown
+---
+source_url: https://example.com/article
+clipped_at: 2025-12-17 14:30:00
+---
+
+*Clipped from [https://example.com/article](https://example.com/article)*
+
+# Article Title
+
+Content converted to markdown...
+```
+
 ## Exporting Notes
 
 Export notes to various formats:


### PR DESCRIPTION
## Summary

Completes the version bump to 0.2.1 with missing updates from the initial release PR.

## Changes

### Version Fix
- Updated `pyproject.toml` from 0.1.13 to 0.2.1 (fixes PyPI upload error)

### Documentation Updates
- Updated README feature list with all Phase 1 features:
  - Note templates
  - Version history
  - Markdown rendering
  - URL import/web clipper
  - Interactive pagination
- Expanded command reference table with new commands
- Added URL import section to `docs/import-export.md` with examples

## Context

The initial v0.2.1 release PR missed updating `pyproject.toml`, causing PyPI upload to fail with version 0.1.13. This PR completes all necessary updates for the v0.2.1 release.

## Test Plan

- [x] Version updated in pyproject.toml
- [x] Documentation accurately reflects new features
- [x] All new commands documented in README