### PR TITLE
Fix unicode encoding error and background sync crash (v0.2.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to GPGNotes will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2025-12-17
+
+### Fixed
+
+- **Unicode Encoding Error**: Fixed `latin-1` codec error when creating notes with Unicode characters (smart quotes, em dashes, etc.). The `sanitize_for_gpg()` function is now applied to all note content before encryption, not just during import. Fixes issue where typing characters like `'` would cause "Error creating note" message.
+
+- **Background Sync Crash**: Fixed exception in atexit callback `_background_sync` that caused Click to be re-invoked with note title words as arguments. Removed redundant auto-tagging from the exit callback since it's already performed immediately when notes are created/imported.
+
 ## [0.2.2] - 2025-12-17
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpgnotes"
-version = "0.2.2"
+version = "0.2.3"
 description = "GPGNotes - A CLI note-taking tool with GPG encryption, tagging, and Git sync"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/gpgnotes/encryption.py
+++ b/src/gpgnotes/encryption.py
@@ -71,7 +71,11 @@ class Encryption:
 
     def encrypt_from_temp(self, temp_path: Path, output_path: Path) -> bool:
         """Read from temp file and encrypt to output path."""
-        with open(temp_path) as f:
+        from .llm import sanitize_for_gpg
+
+        with open(temp_path, encoding="utf-8") as f:
             content = f.read()
 
+        # Sanitize for GPG's latin-1 encoding
+        content = sanitize_for_gpg(content)
         return self.encrypt(content, output_path)

--- a/src/gpgnotes/storage.py
+++ b/src/gpgnotes/storage.py
@@ -7,6 +7,7 @@ from typing import List
 
 from .config import Config
 from .encryption import Encryption
+from .llm import sanitize_for_gpg
 from .note import Note
 
 
@@ -31,8 +32,9 @@ class Storage:
         # Create directory if needed
         full_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Encrypt and save
+        # Encrypt and save (sanitize for GPG's latin-1 encoding)
         markdown_content = note.to_markdown()
+        markdown_content = sanitize_for_gpg(markdown_content)
         self.encryption.encrypt(markdown_content, full_path)
 
         note.file_path = full_path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,7 +21,7 @@ def test_cli_version():
     result = runner.invoke(main, ['--version'])
 
     assert result.exit_code == 0
-    assert '0.2.2' in result.output
+    assert '0.2.3' in result.output
 
 
 def test_config_show(test_config, monkeypatch):


### PR DESCRIPTION
## Summary

- **Unicode Encoding Fix**: Apply `sanitize_for_gpg()` to all note content before GPG encryption, fixing the `latin-1` codec error when typing Unicode characters like smart quotes (`'`).

- **Background Sync Fix**: Simplify `_background_sync()` atexit callback to only handle git sync. Removes redundant auto-tagging that was causing Click to be re-invoked with note title words as CLI arguments.

## Issues Fixed

```
Error creating note: 'latin-1' codec can't encode character '\u2019' in position 336
```

```
Error: Got unexpected extra arguments (acme replacement blackduck justification)
Exception ignored in atexit callback <function _background_sync at ...>
```

## Test plan

- [ ] Create a new note with Unicode characters (smart quotes, em dashes)
- [ ] Verify note saves without encoding error
- [ ] Exit the CLI and verify no background sync crash
- [ ] Run `notes sync` and verify no errors