### PR TITLE
Add template support to shell mode new command (v0.2.6)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpgnotes"
-version = "0.2.5"
+version = "0.2.6"
 description = "GPGNotes - A CLI note-taking tool with GPG encryption, tagging, and Git sync"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/gpgnotes/__init__.py
+++ b/src/gpgnotes/__init__.py
@@ -1,3 +1,3 @@
 """GPGNotes - A CLI note-taking tool with encryption, tagging, and Git sync."""
 
-__version__ = "0.2.5"
+__version__ = "0.2.6"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,7 +21,7 @@ def test_cli_version():
     result = runner.invoke(main, ['--version'])
 
     assert result.exit_code == 0
-    assert '0.2.5' in result.output
+    assert '0.2.6' in result.output
 
 
 def test_config_show(test_config, monkeypatch):


### PR DESCRIPTION
## Summary
- Add template and tags support to the `new` command in shell mode (interactive `notes>` prompt)
- Update help text to show template usage example
- Bump version to 0.2.6

## Problem
When running `new "Title" --template bug` in shell mode, the `--template` option was being ignored because the shell mode parser didn't handle command options.

## Solution
Updated shell mode to use `shlex` for proper argument parsing and extract `--template`, `--tags`, and `-t` options.

## Usage
Now in shell mode you can:
```
notes> new "Bug Report" --template bug
notes> new "Meeting Notes" --template meeting -t work
```

## Test plan
- [x] All 48 tests pass
- [x] Shell mode help shows template example