### PR TITLE
Fix list() built-in shadow bug breaking template creation (v0.2.7)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpgnotes"
-version = "0.2.6"
+version = "0.2.7"
 description = "GPGNotes - A CLI note-taking tool with GPG encryption, tagging, and Git sync"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/gpgnotes/__init__.py
+++ b/src/gpgnotes/__init__.py
@@ -1,3 +1,3 @@
 """GPGNotes - A CLI note-taking tool with encryption, tagging, and Git sync."""
 
-__version__ = "0.2.6"
+__version__ = "0.2.7"

--- a/src/gpgnotes/cli.py
+++ b/src/gpgnotes/cli.py
@@ -209,7 +209,7 @@ def _background_sync():
 
 @click.group(invoke_without_command=True)
 @click.pass_context
-@click.version_option(version="0.2.6")
+@click.version_option(version="0.2.7")
 def main(ctx):
     """GPGNotes - Encrypted note-taking with Git sync."""
     # Register exit handler for background sync
@@ -760,7 +760,7 @@ def _find_note_by_title(storage: Storage, query: str) -> Optional[Path]:
         return None
 
 
-@main.command()
+@main.command("list")
 @click.option("--preview", "-p", is_flag=True, help="Show first line of content")
 @click.option(
     "--sort",
@@ -772,7 +772,7 @@ def _find_note_by_title(storage: Storage, query: str) -> Optional[Path]:
 @click.option("--page-size", "-n", default=20, help="Items per page (default: 20)")
 @click.option("--tag", "-t", help="Filter by tag")
 @click.option("--no-pagination", is_flag=True, help="Disable pagination, show all results")
-def list(preview, sort, page_size, tag, no_pagination):
+def list_cmd(preview, sort, page_size, tag, no_pagination):
     """List all notes with optional filtering and sorting.
 
     Examples:
@@ -897,8 +897,10 @@ def recent(limit):
         notes recent -n 10  # Show 10 most recent
     """
     # Delegate to list command with defaults
-    ctx = click.Context(list)
-    ctx.invoke(list, preview=False, sort="modified", page_size=limit, tag=None, no_pagination=True)
+    ctx = click.Context(list_cmd)
+    ctx.invoke(
+        list_cmd, preview=False, sort="modified", page_size=limit, tag=None, no_pagination=True
+    )
 
 
 @main.command()
@@ -2605,9 +2607,9 @@ def interactive_mode():
 
                 ctx.invoke(new, title=title, tags=tags, template=template, var=())
             elif command == "list":
-                ctx = click.Context(list)
+                ctx = click.Context(list_cmd)
                 ctx.invoke(
-                    list,
+                    list_cmd,
                     preview=False,
                     sort="modified",
                     page_size=20,
@@ -2615,9 +2617,14 @@ def interactive_mode():
                     no_pagination=False,
                 )
             elif command == "recent":
-                ctx = click.Context(list)
+                ctx = click.Context(list_cmd)
                 ctx.invoke(
-                    list, preview=False, sort="modified", page_size=5, tag=None, no_pagination=True
+                    list_cmd,
+                    preview=False,
+                    sort="modified",
+                    page_size=5,
+                    tag=None,
+                    no_pagination=True,
                 )
             elif command == "open" and args:
                 ctx = click.Context(open)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,7 +21,7 @@ def test_cli_version():
     result = runner.invoke(main, ['--version'])
 
     assert result.exit_code == 0
-    assert '0.2.6' in result.output
+    assert '0.2.7' in result.output
 
 
 def test_config_show(test_config, monkeypatch):


### PR DESCRIPTION
## Summary
Fix critical bug where `notes new "Title" --template bug` was printing "No notes found" instead of creating a note from the template.

## Root Cause
The `list` Click command function was shadowing Python's built-in `list()` function. When running the `new` command with a template:

```python
# Line 440 in new() function:
variables = TemplateEngine.parse_variables(list(var))
```

This `list(var)` call was invoking the Click `list` command instead of Python's built-in `list()` to convert the tuple to a list.

## Fix
Rename the function from `list` to `list_cmd` while keeping the CLI command name as `list` via the `@main.command("list")` decorator.

## Test plan
- [x] All 48 tests pass
- [x] `notes new "Title" --template bug` now works correctly (verified in test environment - gets GPG errors as expected without keys, but no longer shows "No notes found")