### PR TITLE
Fix sqlite3.Row .get() bug in list command (v0.2.9)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpgnotes"
-version = "0.2.8"
+version = "0.2.9"
 description = "GPGNotes - A CLI note-taking tool with GPG encryption, tagging, and Git sync"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/gpgnotes/index.py
+++ b/src/gpgnotes/index.py
@@ -190,7 +190,7 @@ class SearchIndex:
                     "tags": row["tags"].split() if row["tags"] else [],
                     "created": row["created"],
                     "modified": row["modified"],
-                    "is_plain": bool(row.get("is_plain", 0)),
+                    "is_plain": bool(row["is_plain"]) if "is_plain" in row.keys() else False,
                 }
             )
 


### PR DESCRIPTION
## Summary
- Fixed AttributeError: 'sqlite3.Row' object has no attribute 'get'
- Updated version to 0.2.9

## Details
The `get_all_metadata()` method in `index.py` was using `row.get("is_plain", 0)` which fails because `sqlite3.Row` objects don't have a `.get()` method like dictionaries do.

Changed to: `bool(row["is_plain"]) if "is_plain" in row.keys() else False`

This bug appeared when the database was recreated and prevented the `notes list` command from functioning.

## Test plan
- [x] Removed database and ran `notes sync` to recreate it
- [x] Verified `notes list` now works correctly
- [x] Confirmed version bump to 0.2.9