### PR TITLE
Fix git sync to auto-configure remote and push all commits (v0.2.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to GPGNotes will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.13] - 2025-12-17
+
+### Fixed
+
+- **Git Sync**: Fixed `notes sync` command to properly configure git remote for existing repositories. Previously, the remote URL was only configured when initializing a new repository, causing sync failures for existing repos.
+- **Git Sync Push**: Fixed sync command to push all unpushed commits, not just newly created ones. This ensures plain notes and all other changes are properly uploaded to GitHub.
+
 ## [0.2.12] - 2025-12-17
 
 *Same as 0.2.11 - version bump for PR*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpgnotes"
-version = "0.2.12"
+version = "0.2.13"
 description = "GPGNotes - A CLI note-taking tool with GPG encryption, tagging, and Git sync"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Fixed two critical issues with the `notes sync` command that prevented plain notes and other changes from being uploaded to GitHub.

## Issues Fixed

### 1. Remote Not Auto-Configured for Existing Repos
**Problem**: The `init_repo()` method only configured the git remote URL when creating a NEW repository. For existing repositories, the remote was never added, causing sync to fail silently.

**Solution**: Modified `init_repo()` to check and configure the remote for existing repositories:
- Checks if remote exists, adds it if missing
- Updates remote URL if it doesn't match config
- Works for both new and existing repositories

### 2. Sync Only Pushed New Commits
**Problem**: The `sync()` method only pushed when there were newly created commits in that sync call. If there were already unpushed commits (like plain note exports), they would never be pushed.

**Solution**: Changed sync logic to always push when a remote is configured, ensuring all unpushed commits reach GitHub.

## Changes

**src/gpgnotes/sync.py**:
```python
# init_repo() - Added remote configuration for existing repos
if remote_url:
    if not self.repo.remotes:
        self.repo.create_remote("origin", remote_url)
    elif "origin" not in [r.name for r in self.repo.remotes]:
        self.repo.create_remote("origin", remote_url)
    else:
        origin = self.repo.remotes.origin
        if origin.url != remote_url:
            origin.set_url(remote_url)

# sync() - Push all unpushed commits
if self.has_remote():
    return self.push()
```

**pyproject.toml**: Version bump to 0.2.13
**CHANGELOG.md**: Documented fixes

## Testing

✅ Manual testing confirmed:
1. Removed remote from existing repo
2. Ran `notes sync` - remote auto-configured
3. Plain notes successfully uploaded to GitHub
4. All unpushed commits pushed correctly

## Impact

Users can now reliably sync their plain notes and all other changes to GitHub without manual git remote configuration.