### PR TITLE
Release v0.3.2: Full plain notes support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to GPGNotes will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2025-12-18
+
+### Added
+
+- **Full Plain Notes Support**: Complete support for creating and managing unencrypted notes (closes #17).
+  - `notes new "Title" --plain` - Create plain (unencrypted) note directly
+  - `notes decrypt <id>` - Convert encrypted note to plain
+  - `notes encrypt <id>` - Convert plain note to encrypted
+  - `notes list --plain` - Show only plain notes
+  - `notes list --encrypted` - Show only encrypted notes
+  - Plain notes stored in `notes/plain/` directory
+  - Full interactive mode support for all new commands
+
+- **Storage Method**: New `save_plain_note()` method in Storage class for creating plain notes without encryption.
+
+### Changed
+
+- **Interactive Mode**: Added `encrypt`, `decrypt` commands and `--plain` option for `new` and `list` commands.
+- **Tab Completion**: Added `encrypt` and `decrypt` to autocomplete commands.
+- **Help Text**: Updated interactive mode help with new plain note commands and options.
+
 ## [0.3.1] - 2025-12-18
 
 ### Added
@@ -501,6 +522,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sync requires Git remote to be configured manually
 - Initial sync from existing remote requires `--allow-unrelated-histories` (handled automatically)
 
+[0.3.2]: https://github.com/oscarvalenzuelab/GPGNotes/releases/tag/v0.3.2
 [0.3.1]: https://github.com/oscarvalenzuelab/GPGNotes/releases/tag/v0.3.1
 [0.3.0]: https://github.com/oscarvalenzuelab/GPGNotes/releases/tag/v0.3.0
 [0.2.12]: https://github.com/oscarvalenzuelab/GPGNotes/releases/tag/v0.2.12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpgnotes"
-version = "0.3.1"
+version = "0.3.2"
 description = "GPGNotes - A CLI note-taking tool with GPG encryption, tagging, and Git sync"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/gpgnotes/__init__.py
+++ b/src/gpgnotes/__init__.py
@@ -1,3 +1,3 @@
 """GPGNotes - A CLI note-taking tool with encryption, tagging, and Git sync."""
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/src/gpgnotes/storage.py
+++ b/src/gpgnotes/storage.py
@@ -41,6 +41,29 @@ class Storage:
         note.file_path = full_path
         return full_path
 
+    def save_plain_note(self, note: Note) -> Path:
+        """Save note to disk without encryption (plain markdown)."""
+        note.update_modified()
+        note.is_plain = True
+
+        # Get relative path and create full path in plain directory
+        rel_path = note.get_relative_path()
+        # Remove .gpg extension for plain files
+        rel_path_str = str(rel_path)
+        if rel_path_str.endswith(".gpg"):
+            rel_path_str = rel_path_str[:-4]  # Remove .gpg
+        full_path = self.plain_dir / rel_path_str
+
+        # Create directory if needed
+        full_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Save as plain markdown
+        markdown_content = note.to_markdown()
+        full_path.write_text(markdown_content, encoding="utf-8")
+
+        note.file_path = full_path
+        return full_path
+
     def load_note(self, file_path: Path) -> Note:
         """Load and decrypt note from disk."""
         if not file_path.exists():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,7 +21,7 @@ def test_cli_version():
     result = runner.invoke(main, ['--version'])
 
     assert result.exit_code == 0
-    assert '0.3.1' in result.output
+    assert '0.3.2' in result.output
 
 
 def test_config_show(test_config, monkeypatch):


### PR DESCRIPTION
## Summary

Implements the remaining features from issue #17 to provide full support for plain (unencrypted) notes.

### Added
- **`notes new "Title" --plain`** - Create plain (unencrypted) note directly
- **`notes decrypt <id>`** - Convert encrypted note to plain (with confirmation)
- **`notes encrypt <id>`** - Convert plain note to encrypted (with confirmation)  
- **`notes list --plain`** - Show only plain (unencrypted) notes
- **`notes list --encrypted`** - Show only encrypted notes
- **`save_plain_note()`** - New Storage method for creating plain notes

### Changed
- Interactive mode: Added `encrypt`, `decrypt` commands and `--plain` option for `new` and `list`
- Tab completion: Added `encrypt` and `decrypt` to autocomplete
- Help text: Updated with new plain note commands and options

Closes #17

## Test plan
- [ ] Create plain note: `notes new "Test" --plain`
- [ ] Verify it appears in `notes list --plain`
- [ ] Verify it doesn't appear in `notes list --encrypted`
- [ ] Encrypt it: `notes encrypt <id>`
- [ ] Verify it now appears in `notes list --encrypted`
- [ ] Decrypt it back: `notes decrypt <id>`
- [ ] Test in interactive mode: `new "Test" --plain`, `list --plain`, `encrypt <id>`, `decrypt <id>`